### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/le0pard/storybook-addon-root-attribute.git"
+    "url": "git+https://github.com/le0pard/storybook-addon-root-attribute.git"
   },
   "keywords": [
     "storybook",


### PR DESCRIPTION
## Summary

- update the package repository URL from SSH to `git+https`

## Validation

- checked `package.json` parses and points to `git+https://github.com/le0pard/storybook-addon-root-attribute.git`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
